### PR TITLE
Updated .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: perl
-perl:
-  - "5.22"
-  - "5.24"
-  - "5.26"
-  - "5.28"
-  - "5.30"
+matrix:
+  include:
+  - perl: "5.10"
+    dist: trusty
+  - perl: "5.12"
+    dist: trusty
+  - perl: "5.14"
+    dist: trusty
+  - perl: "5.16"
+    dist: trusty
+  - perl: "5.18"
+    dist: trusty
+  - perl: "5.20"
+    dist: trusty
+  - perl: "5.22"
+  - perl: "5.24"
+  - perl: "5.26"
+  - perl: "5.28"
+  - perl: "5.30"
 
 before_install:
   - cpanm -n Module::Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: perl
 perl:
-  - "5.12"
-  - "5.14"
-  - "5.16"
-  - "5.18"
-  - "5.20"
   - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "5.30"
 
 before_install:
-  cpanm -n Devel::Cover::Report::Coveralls
+  - cpanm -n Module::Build
+  - cpanm -n Devel::Cover::Report::Coveralls
 
 script:
   perl Build.PL && ./Build build && cover -test +ignore Build.pm -report coveralls


### PR DESCRIPTION
Hello, this is from [pullrequest.club](https://pullrequest.club/)!

I have updated `.travis.yml` to use the Ubuntu 16.04 (Xenial) build environment. In this environment `perl` versions before 5.22 are not available, see 
https://travis-ci.community/t/failure-with-perl-5-16-5-18-5-20/2458

Also from Perl 5.22, `Module::Build` is not in core, see: 
https://metacpan.org/pod/release/RJBS/perl-5.22.0-RC2/pod/perldelta.pod
so added that as a `before_install` dependency in `.travis.yml`.